### PR TITLE
Add SQL Premier League

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The platforms I've reviewed so far are listed below by their relative difficulty
 ### 🟢 Easy
 
 - [Analyst Builder](https://www.analystbuilder.com/) ([review](src/reviews.md#analyst-builder))
+- [SQL Premier League](https://sqlpremierleague.com/challenges/) ([review](src/reviews.md#sql-premier-league))
 - [SQL Short Reads](https://sqlshortreads.com/sql-practice-problems/) ([review](src/reviews.md#sql-short-reads))
 - [StrataScratch](https://platform.stratascratch.com/coding) ([review](src/reviews.md#stratascratch))
 - [SQL Murder Mystery](https://mystery.knightlab.com/) ([review](src/reviews.md#sql-murder-mystery))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,9 +59,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
 
-  strata-scratch:
-    image: postgres:16.7
-    container_name: StrataScratch
+  sql-premier-league:
+    image: postgres:16.8
+    container_name: SQLPremierLeague
     ports: ["5435:5432"]
     profiles: ["skip"]
     environment:
@@ -78,3 +78,12 @@ services:
       ORACLE_SID: DEFAULT
       # username is `SYSTEM`
       ORACLE_PWD: oracle
+
+  strata-scratch:
+    image: postgres:16.7
+    container_name: StrataScratch
+    ports: ["5436:5432"]
+    profiles: ["skip"]
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres

--- a/src/reviews.md
+++ b/src/reviews.md
@@ -39,9 +39,43 @@ For the most part, the recommended solutions are good.
 
 ### Cons ❌
 
-The "hard" problems are _waaay_ easier than the DataLemur ones; they're more like "medium" DataLemur ones.
+The "hard" problems are _very_ easy. Hopefully the "very hard" problems are actually hard, but I can't say for sure.
 
-Hopefully the "very hard" problems are actually hard, but I can't say for sure.
+These questions are good for someone who's just starting out with SQL, but not for someone who's been working with SQL for a while.
+
+---
+
+## SQL Premier League
+
+> [!NOTE]
+>
+> The problems are available at:
+>
+> - https://sqlpremierleague.com/challenges/
+>
+> The platform uses PostgreSQL only.
+>
+> There are _loads_ of problems, and a live query editor.
+>
+> I only attempted a few hard questions, but they were too easy for me to want to do any more.
+
+### Pros ✔️
+
+There are _loads_ of questions, across a few different sports -- great for anyone with an interest in sports!
+
+Each question has a submission history, discussions tab, and hints.
+
+Each question has the required tables, and the first three rows from each table.
+
+There's a "Report and Issue" button on the questions, which is handy for submitting bug reports.
+
+There is a leaderboard and a nice user profile page.
+
+### Cons ❌
+
+The platform doesn't seem to support CTEs, even though they're valid PostgreSQL syntax.
+
+The "hard" problems are very easy.
 
 These questions are good for someone who's just starting out with SQL, but not for someone who's been working with SQL for a while.
 

--- a/src/sql-premier-league/closest-race-finishes.sql
+++ b/src/sql-premier-league/closest-race-finishes.sql
@@ -1,0 +1,104 @@
+/* https://sqlpremierleague.com/solve/169 */
+
+
+/* Sample data */
+create table f1_circuits (
+    circuit_id int,
+    circuit_ref text,
+    circuit_name text,
+    location text,
+    country text,
+    latitude numeric(8, 5),
+    longitude numeric(8, 5),
+    altitude int,
+    wikipedia_url text
+);
+insert into f1_circuits
+values
+    (1, 'albert_park', 'Albert Park Grand Prix Circuit', 'Melbourne',    'Australia', -37.8497,  144.968,  10, 'https://en.wikipedia.org/wiki/Melbourne_Grand_Prix_Circuit'),
+    (2, 'sepang',      'Sepang International Circuit',   'Kuala Lumpur', 'Malaysia',    2.76083, 101.738,  18, 'https://en.wikipedia.org/wiki/Sepang_International_Circuit'),
+    (3, 'bahrain',     'Bahrain International Circuit',  'Sakhir',       'Bahrain',    26.0325,   50.5106,  7, 'https://en.wikipedia.org/wiki/Bahrain_International_Circuit')
+;
+
+create table f1_races (
+    race_id int,
+    year int,
+    round int,
+    circuit_id int,
+    race_name text,
+    race_date date,
+    race_time time,
+    wikipedia_url text,
+    fp1_date date,
+    fp1_time time,
+    fp2_date date,
+    fp2_time time,
+    fp3_date date,
+    fp3_time time,
+    quali_date date,
+    quali_time time,
+    sprint_date date,
+    sprint_time time
+);
+insert into f1_races
+values
+    (1, 2009, 1,  1, 'Australian Grand Prix', '2009-03-29', '06:00:00', 'https://en.wikipedia.org/wiki/2009_Australian_Grand_Prix', null, null, null, null, null, null, null, null, null, null),
+    (2, 2009, 2,  2, 'Malaysian Grand Prix',  '2009-04-05', '09:00:00', 'https://en.wikipedia.org/wiki/2009_Malaysian_Grand_Prix',  null, null, null, null, null, null, null, null, null, null),
+    (3, 2009, 3, 17, 'Chinese Grand Prix',    '2009-04-19', '07:00:00', 'https://en.wikipedia.org/wiki/2009_Chinese_Grand_Prix',    null, null, null, null, null, null, null, null, null, null)
+;
+
+create table f1_results (
+    result_id int,
+    race_id int,
+    driver_id int,
+    constructor_id int,
+    grid_position int,
+    final_position int,
+    position_text int,
+    position_order int,
+    points int,
+    laps int,
+    race_time text,
+    milliseconds int,
+    fastest_lap int,
+    fastest_lap_rank int,
+    fastest_lap_time text,
+    fastest_lap_speed numeric(8, 3),
+    status_id int
+);
+insert into f1_results
+values
+    (138, 24,  3, 3, 5, 10, 10, 10,  0, 70, '+54.749',     5838976, 14, 5, '1:17.977', 201.336, 1),
+    (149, 25, 13, 6, 2,  1,  1,  1, 10, 70, '1:31:50.245', 5510245, 20, 2, '1:16.729', 206.956, 1),
+    (150, 25,  8, 6, 1,  2,  2,  2,  8, 70, '+17.984',     5528229, 16, 1, '1:16.630', 207.224, 1)
+;
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+/* Solution */
+with time_diff as (
+    select
+        race_id,
+        pos_2.milliseconds - pos_1.milliseconds as diff_ms
+    from f1_results as pos_1
+        inner join f1_results as pos_2
+            using (race_id)
+    where 1=1
+        and pos_1.position_order = 1
+        and pos_2.position_order = 2
+)
+
+select
+    f1_circuits.circuit_name,
+    avg(time_diff.diff_ms) / 1000 as avg_diff_sec
+from f1_circuits
+    inner join f1_races
+        using (circuit_id)
+    inner join time_diff
+        using (race_id)
+group by f1_circuits.circuit_name
+order by avg_diff_sec
+limit 1
+;

--- a/src/sql-premier-league/highest-average-points.sql
+++ b/src/sql-premier-league/highest-average-points.sql
@@ -1,0 +1,73 @@
+/* https://sqlpremierleague.com/solve/364 */
+
+
+/* Sample data */
+create table clubrankings (
+    position int,
+    club text,
+    country text,
+    participated int,
+    titles int,
+    played int,
+    win int,
+    draw int,
+    loss int,
+    goals_for int,
+    goals_against int,
+    pts int,
+    goal_diff int
+);
+insert into clubrankings
+values
+    (1, 'Real Madrid CF',    'ESP', 53, 14, 476, 285, 81, 110, 1047, 521, 651, 526),
+    (2, 'FC Bayern München', 'GER', 39,  6, 382, 229, 76,  77,  804, 373, 534, 431),
+    (3, 'FC Barcelona',      'ESP', 33,  5, 339, 197, 76,  66,  667, 343, 470, 324)
+;
+
+create table countrymapping (
+    country_code text,
+    country_name text
+);
+insert into countrymapping
+values
+    ('ESP', 'Spain'),
+    ('GER', 'Germany'),
+    ('ENG', 'England')
+;
+
+create table countryrankings (
+    rank int,
+    country text,
+    participated int,
+    titles int,
+    played int,
+    win int,
+    draw int,
+    loss int,
+    goals_for int,
+    goals_against int,
+    pts int,
+    goal_diff int
+);
+insert into countryrankings
+values
+    (1, 'Spain',   152, 19, 1379, 717, 313, 349, 2476, 1492, 1747, 984),
+    (2, 'England', 140, 15, 1278, 676, 280, 322, 2289, 1299, 1632, 990),
+    (3, 'Germany', 171,  8, 1216, 573, 250, 393, 2128, 1589, 1396, 539)
+;
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+/* Solution */
+select
+    countrymapping.country_name,
+    avg(clubrankings.pts) as average_points
+from countrymapping
+    inner join clubrankings
+        on countrymapping.country_code = clubrankings.country
+group by countrymapping.country_name
+order by average_points desc
+limit 1
+;

--- a/src/sql-premier-league/most-triple-doubles.sql
+++ b/src/sql-premier-league/most-triple-doubles.sql
@@ -1,0 +1,110 @@
+/* https://sqlpremierleague.com/solve/190 */
+
+
+/* Sample data */
+create table nba_game_details (
+    game_id int,
+    team_id int,
+    player_id int,
+    start_position text,
+    minutes text,
+    fgm int,  /* field goals made */
+    fga int,  /* field goals attempted */
+    fg_pct numeric(5, 3),
+    fg3m int,  /* 3-point field goals made */
+    fg3a int,  /* 3-point field goals attempted */
+    fg3_pct numeric(5, 3),
+    ftm int,  /* free throws made */
+    fta int,  /* free throws attempted */
+    ft_pct numeric(5, 3),
+    oreb int,  /* offensive rebounds */
+    dreb int,  /* defensive rebounds */
+    reb int,  /* rebounds */
+    ast int,  /* assists */
+    stl int,  /* steals */
+    blk int,  /* blocks */
+    turnover int,
+    pf int,  /* personal fouls */
+    pts int,  /* points */
+    plus_minus numeric(5, 2)
+);
+insert into nba_game_details
+values
+    (21400097, 1610612747, 202325, 'F', '35:28', 2,  6, 0.333, 1, 2, 0.500, 0, 0, 0.000, 0, 3, 3, 0, 1, 0, 0, 1,  5, 7.00),
+    (21400097, 1610612747,   2430, 'F', '30:14', 7, 11, 0.636, 0, 0, 0.000, 2, 2, 1.000, 0, 5, 5, 1, 1, 0, 2, 5, 16, 5.00),
+    (21400097, 1610612747, 201941, 'C', '29:38', 6, 12, 0.500, 0, 0, 0.000, 0, 0, 0.000, 2, 4, 6, 7, 0, 0, 1, 4, 12, 4.00)
+;
+
+create table nba_games (
+    game_id int,
+    game_date date,
+    game_status text,
+    home_team_id int,
+    visitor_team_id int,
+    season int,
+    home_team_points int,
+    away_team_points int,
+    home_fg_pct numeric(5, 3),
+    home_ft_pct numeric(5, 3),
+    home_fg3_pct numeric(5, 3),
+    home_assists int,
+    home_rebounds int,
+    away_fg_pct numeric(5, 3),
+    away_ft_pct numeric(5, 3),
+    away_fg3_pct numeric(5, 3),
+    away_assists int,
+    away_rebounds int,
+    home_team_wins int
+);
+insert into nba_games
+values
+    (22200477, '2022-12-22', 'Final', 1610612740, 1610612759, 2022, 126, 117, 0.484, 0.926, 0.382, 25, 46, 0.478, 0.815, 0.321, 23, 44, 1),
+    (22200478, '2022-12-22', 'Final', 1610612762, 1610612764, 2022, 120, 112, 0.488, 0.952, 0.457, 16, 40, 0.561, 0.765, 0.333, 20, 37, 1),
+    (22200466, '2022-12-21', 'Final', 1610612739, 1610612749, 2022, 114, 106, 0.482, 0.786, 0.313, 22, 37, 0.470, 0.682, 0.433, 20, 46, 1)
+;
+
+create table nba_players (
+    player_id int,
+    player_name text,
+    team_id int,
+    season int
+);
+insert into nba_players
+values
+    (1626220, 'Royce O''Neale',   1610612762, 2019),
+    ( 202711, 'Bojan Bogdanovic', 1610612762, 2019),
+    ( 203497, 'Rudy Gobert',      1610612762, 2019)
+;
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+/* Solution */
+with most_triple_doubles as (
+    select
+        nba_games.season,
+        nba_game_details.player_id,
+        count(*) as total_triple_doubles
+    from nba_games
+        left join nba_game_details
+            using (game_id)
+    where 1=1
+        and nba_game_details.pts >= 10
+        and nba_game_details.reb >= 10
+        and nba_game_details.ast >= 10
+    group by
+        nba_games.season,
+        nba_game_details.player_id
+    order by total_triple_doubles desc
+    limit 1
+)
+
+select
+    nba_players.player_name,
+    most_triple_doubles.season,
+    most_triple_doubles.total_triple_doubles
+from most_triple_doubles
+    left join nba_players
+        using (player_id)
+;


### PR DESCRIPTION
## Summary by Sourcery

Add review and SQL solutions for SQL Premier League platform, and update project configuration

New Features:
- Added review for SQL Premier League platform in reviews.md
- Added three SQL solution examples from SQL Premier League

Enhancements:
- Updated docker-compose.yaml to include SQL Premier League database configuration
- Reorganized StrataScratch and SQL Premier League database port mappings

Documentation:
- Updated README.md to include SQL Premier League in the list of easy SQL practice platforms